### PR TITLE
Fix readme typo - Usage installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the npm package to your project:
 $ yarn add @jimdo/serverless-dotenv
 
 # Via npm
-$ npm instal @jimdo/serverless-dotenv --save
+$ npm install @jimdo/serverless-dotenv --save
 ```
 
 Add the plugin to your `serverless.yml`:


### PR DESCRIPTION
There's a typo under usage section to install the plugin via npm. 